### PR TITLE
Add support for unfreezing arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ shallowCopy = objectUnfreeze(subject);
 shallowCopy.foo = 'FOO';
 ```
 
+---
+
+```js
+import objectUnfreeze from 'object-unfreeze';
+
+let subject,
+    shallowCopy;
+
+subject = [];
+
+Object.freeze(subject);
+
+// Throws an error.
+// subject.push('FOO');
+
+shallowCopy = objectUnfreeze(subject);
+
+shallowCopy.push('FOO');
+```
+
 ## Download
 
 Download using NPM:

--- a/src/objectUnfreeze.js
+++ b/src/objectUnfreeze.js
@@ -2,11 +2,18 @@
  * Make a shallow copy of the object maintaining the prototype.
  */
 export default (source: Object): Object => {
-    const target = {};
+    let target;
 
-    for (const property in source) {
-        if (source.hasOwnProperty(property)) {
-            target[property] = source[property];
+    if (source.constructor === Array) {
+        target = source.map((element) => {
+            return element;
+        });
+    } else {
+        target = {};
+        for (const property in source) {
+            if (source.hasOwnProperty(property)) {
+                target[property] = source[property];
+            }
         }
     }
 

--- a/tests/objectUnfreeze.js
+++ b/tests/objectUnfreeze.js
@@ -45,3 +45,41 @@ describe('objectUnfreeze()', () => {
         });
     });
 });
+
+describe('objectUnfreeze() on Array', () => {
+    context('frozen array', () => {
+        let subject;
+
+        beforeEach(() => {
+            subject = ['foo'];
+
+            Object.freeze(subject);
+        });
+
+        context('manipulating the frozen array', () => {
+            it('throws an error', () => {
+                expect(() => {
+                    subject.push('test');
+                }).to.throw(Error, `Can\'t add property ${subject.length}, object is not extensible`);
+            });
+        });
+
+        it('does not affect the target array', () => {
+            objectUnfreeze(subject);
+
+            expect(() => {
+                subject.push('test');
+            }).to.throw(Error, `Can\'t add property ${subject.length}, object is not extensible`);
+        });
+
+        it('creates a shallow copy of the target array', () => {
+            const shallowCopy = objectUnfreeze(subject);
+
+            expect(shallowCopy[0]).to.equal('foo');
+
+            shallowCopy.push('bar');
+
+            expect(shallowCopy[1]).to.equal('bar');
+        });
+    });
+});


### PR DESCRIPTION
Adds support for shallow-copying frozen array objects. 

Linter is throwing a `Using 'TemplateLiteral' is not allowed` due to the expected error messages. Let me know if I should change that to use concatenation instead.
